### PR TITLE
feat: add supply-chain security pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+* @maisaai/developers
+.dockerignore @maisaai/sre
+.github/workflows/ @maisaai/sre
+.github/CODEOWNERS @maisaai/sre
+.gitignore @maisaai/sre
+.mega-linter.yml @maisaai/sre
+.maisa/ @maisaai/sre
+CHANGELOG.md @maisaai/sre
+Dockerfile @maisaai/sre
+LICENSE.md @maisaai/sre
+SECURITY.md @maisaai/sre
+VERSION @maisaai/sre
+dependabot.yaml @maisaai/sre
+sonar-project.properties @maisaai/sre
+.golang-ci.yaml @maisaai/sre
+.releaserc @maisaai/sre

--- a/.github/workflows/pr-supply-chain-security.yaml
+++ b/.github/workflows/pr-supply-chain-security.yaml
@@ -16,9 +16,9 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: maisaai/maisa-ci-cd/.github/workflows/supply-chain-pr.yml@feature/supply-chain-sbom-attestation
+    uses: maisaai/maisa-ci-cd/.github/workflows/supply-chain-pr.yml@main
     with:
-      ci_cd_ref: feature/supply-chain-sbom-attestation
+      ci_cd_ref: main
       fail_on_findings: false
       enable_issue_sync: false
     secrets:

--- a/.github/workflows/pr-supply-chain-security.yaml
+++ b/.github/workflows/pr-supply-chain-security.yaml
@@ -1,0 +1,28 @@
+name: PR Supply Chain Security
+run-name: PR supply chain for ${{ github.ref_name }}
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  security-events: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  supply-chain:
+    uses: maisaai/maisa-ci-cd/.github/workflows/supply-chain-pr.yml@feature/supply-chain-sbom-attestation
+    with:
+      ci_cd_ref: feature/supply-chain-sbom-attestation
+      fail_on_findings: false
+      enable_issue_sync: false
+    secrets:
+      SHARED_ACCOUNT_AWS_ROLE_ARN: ${{ secrets.SHARED_ACCOUNT_AWS_ROLE_ARN }}
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/release-supply-chain-security.yaml
+++ b/.github/workflows/release-supply-chain-security.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 permissions:
   actions: read
@@ -17,9 +17,9 @@ permissions:
 
 jobs:
   supply-chain:
-    uses: maisaai/maisa-ci-cd/.github/workflows/supply-chain-release.yml@feature/supply-chain-sbom-attestation
+    uses: maisaai/maisa-ci-cd/.github/workflows/supply-chain-release.yml@main
     with:
-      ci_cd_ref: feature/supply-chain-sbom-attestation
+      ci_cd_ref: main
       fail_on_findings: true
       enable_issue_sync: false
     secrets:

--- a/.github/workflows/release-supply-chain-security.yaml
+++ b/.github/workflows/release-supply-chain-security.yaml
@@ -1,0 +1,29 @@
+name: Release Supply Chain Security
+run-name: Release supply chain for ${{ github.ref_name }}
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  security-events: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  supply-chain:
+    uses: maisaai/maisa-ci-cd/.github/workflows/supply-chain-release.yml@feature/supply-chain-sbom-attestation
+    with:
+      ci_cd_ref: feature/supply-chain-sbom-attestation
+      fail_on_findings: true
+      enable_issue_sync: false
+    secrets:
+      SHARED_ACCOUNT_AWS_ROLE_ARN: ${{ secrets.SHARED_ACCOUNT_AWS_ROLE_ARN }}
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,0 +1,18 @@
+# MegaLinter v9 Configuration
+# Profile: service-python-template
+# Applied via supply-chain-pr.yml SAST lane
+APPLY_FIXES: none
+ENABLE_LINTERS:
+  - REPOSITORY_SEMGREP
+  - REPOSITORY_DEVSKIM
+  - REPOSITORY_GITLEAKS
+  - PYTHON_BANDIT
+  - PYTHON_RUFF
+  - DOCKERFILE_HADOLINT
+DISABLE_LINTERS: []
+SHOW_ELAPSED_TIME: true
+FILEIO_REPORTER: false
+SARIF_REPORTER: true
+GITHUB_STATUS_REPORTER: true
+FLAVOR_SUGGESTIONS: false
+FILTER_REGEX_EXCLUDE: '(__pycache__/|\.eggs/|\.tox/|venv/|\.venv/)'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # Maisa Python API library
 
+[![Supply Chain PR](https://github.com/maisaai/python-sdk/actions/workflows/pr-supply-chain-security.yaml/badge.svg)](https://github.com/maisaai/python-sdk/actions/workflows/pr-supply-chain-security.yaml)
+[![Supply Chain Release](https://github.com/maisaai/python-sdk/actions/workflows/release-supply-chain-security.yaml/badge.svg)](https://github.com/maisaai/python-sdk/actions/workflows/release-supply-chain-security.yaml)
+
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=maisaai_python-sdk&metric=security_rating)](https://sonarcloud.io/summary/overall?id=maisaai_python-sdk)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=maisaai_python-sdk&metric=reliability_rating)](https://sonarcloud.io/summary/overall?id=maisaai_python-sdk)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=maisaai_python-sdk&metric=sqale_rating)](https://sonarcloud.io/summary/overall?id=maisaai_python-sdk)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=maisaai_python-sdk&metric=coverage)](https://sonarcloud.io/summary/overall?id=maisaai_python-sdk)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=maisaai_python-sdk&metric=duplicated_lines_density)](https://sonarcloud.io/summary/overall?id=maisaai_python-sdk)
+[![Security Hotspots](https://sonarcloud.io/api/project_badges/measure?project=maisaai_python-sdk&metric=security_hotspots)](https://sonarcloud.io/summary/overall?id=maisaai_python-sdk)
+
+[![GitHub issues](https://img.shields.io/github/issues/maisaai/python-sdk)](https://github.com/maisaai/python-sdk/issues)
+[![Dependabot Status](https://img.shields.io/badge/dependabot-enabled-025E8C?logo=dependabot)](https://github.com/maisaai/python-sdk/network/updates)
+
+---
+
+
 [![PyPI version](https://img.shields.io/pypi/v/maisa.svg)](https://pypi.org/project/maisa/)
 
 The Maisa Python library provides convenient access to the Maisa REST API from any Python 3.7+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the `main` branch.
+
+## Reporting a Vulnerability
+
+Do not open public issues for security reports.
+
+Use GitHub private vulnerability reporting for this repository, or contact the maintainers directly through internal security channels.
+
+Include:
+- A clear impact statement
+- Reproduction steps or proof of concept
+- Affected paths and versions
+- Suggested remediation if available
+
+We will acknowledge receipt, triage severity, and coordinate a fix and disclosure timeline.


### PR DESCRIPTION
## Summary
- Adds PR and release workflow callers for the centralized supply-chain security pipeline
- Pipeline includes: SBOM generation, vulnerability scanning (Grype, Trivy, OSV), license analysis (ScanCode, ORT), policy compliance (Conftest), Scorecard, Cosign attestation
- References `maisaai/maisa-ci-cd@main` for all reusable workflows

## Test plan
- [ ] Verify supply-chain PR workflow triggers on this PR
- [ ] Check all pipeline lanes complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)